### PR TITLE
Correct path for 64-bit wget line

### DIFF
--- a/source/getting_started/install.rst
+++ b/source/getting_started/install.rst
@@ -82,8 +82,8 @@ can use the command line.
 ::
 
     cd ~
-    wget http://c758482.r82.cf2.rackcdn.com/Sublime Text 2.0.1 x64.tar.bz2
-    tar vxjf Sublime\ Text\ 2.0.1\ x64.tar.bz2
+    wget http://c758482.r82.cf2.rackcdn.com/Sublime Text 2.0.2 x64.tar.bz2
+    tar vxjf Sublime\ Text\ 2.0.2\ x64.tar.bz2
 
 
 Now we should move the uncompressed files to an appropriate location.


### PR DESCRIPTION
I don't know if this has fallen out of date, but the path for the 64-bit install was incorrect.

Not sure how it can be kept up to date permanently, since this'll happen again, but seems worth fixing it for now if the updates aren't particularly rapid.
