### PR TITLE
Fix backslash rendering bug in "Packages/User"

### DIFF
--- a/source/extensibility/macros.rst
+++ b/source/extensibility/macros.rst
@@ -27,7 +27,7 @@ How to Edit Macros
 ******************
 
 As an alternative to recording a macro, you can edit it by hand. Just save a new file
-with the extension ``.sublime-macro`` under :file:`Packages\User` and add
+with the extension ``.sublime-macro`` under :file:`Packages/User` and add
 commands to it. Macro files have this format::
 
    [


### PR DESCRIPTION
Backslash in "Packages\User" causes it to render as "PackagesUser". Changing the backslash to a forward slash should fix that and render as "Packages/User" like intended.
