### PR TITLE
Fix autocomplete plugin example code

### DIFF
--- a/source/extensibility/plugins.rst
+++ b/source/extensibility/plugins.rst
@@ -184,7 +184,7 @@ for plugins go, this a very bad one.
 	import sublime, sublime_plugin
 
 	from xml.etree import ElementTree as ET
-	from urllib import urlopen
+	from urllib.request import urlopen
 
 	GOOGLE_AC = r"http://google.com/complete/search?output=toolbar&q=%s"
 


### PR DESCRIPTION
Since the `urllib` module [has been split into three parts in Python 3](http://docs.python.org/2/library/urllib.html), the example code in Extensibility > Plugins didn't work with Sublime Text 3.

This pull request fixed the code, and it works well with Sublime Text 3.
