### PR TITLE
Update commands reference; added toggle_menu

### DIFF
--- a/source/reference/commands.rst
+++ b/source/reference/commands.rst
@@ -201,6 +201,9 @@ Commands
 **toggle_tabs**
 	Shows or hides the tab bar.
 
+**toggle_menu**
+	Shows or hides the menu bar.
+
 **toggle_minimap**
 	Shows or hides the minimap.
 


### PR DESCRIPTION
Recently toggle_menu was added to SublimeText, added it here since it was missing from the list.
