### PR TITLE
add 'backers' section

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -3,8 +3,16 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+
+Backers 2014
+============
+
+`Backers 2014 <backers_2014/backers_2014.html>`_
+
+
 Sublime Text Unofficial Documentation
 =====================================
+
 
 .. toctree::
    :maxdepth: 2
@@ -23,10 +31,6 @@ Sublime Text Unofficial Documentation
    Glossary <glossary/glossary>
 
 
-Backers 2014
-============
-
-`Backers 2014 <backers_2014/backers_2014.html>`_
 
 .. Indices and tables
 .. ==================


### PR DESCRIPTION
I've managed to fix #111; the dependencies are now installed into the venv.

But the top-level link to the backers' list isn't displayed, so I'm adding this section to the top of the intro. This way it should be more noticeable.
