### PR TITLE
Update it to make example plugin code work with python 3

### DIFF
--- a/source/extensibility/plugins.rst
+++ b/source/extensibility/plugins.rst
@@ -187,14 +187,14 @@ for plugins go, this a very bad one.
     import sublime, sublime_plugin
 
     from xml.etree import ElementTree as ET
-    from urllib import urlopen
+    import urllib
 
     GOOGLE_AC = r"http://google.com/complete/search?output=toolbar&q=%s"
 
     class GoogleAutocomplete(sublime_plugin.EventListener):
         def on_query_completions(self, view, prefix, locations):
             elements = ET.parse(
-                urlopen(GOOGLE_AC % prefix)
+                urllib.request.urlopen(GOOGLE_AC % prefix)
             ).getroot().findall("./CompleteSuggestion/suggestion")
 
             sugs = [(x.attrib["data"],) * 2 for x in elements]


### PR DESCRIPTION
It will now work on Python 3 as I updated the url fetching.
Python 3 is standard for sublime text so it should be fine to anyone running this. If it doesn't work it is most likely because they are using Python 2 which they shouldn't be using in the first place!
