### PR TITLE
Edit package docs

### DIFF
--- a/source/basic_concepts.rst
+++ b/source/basic_concepts.rst
@@ -55,6 +55,7 @@ we'll outline key aspects
 that you'll get familiar with
 after you've spent some time using the editor.
 
+.. _data-directory:
 
 The *Data* Directory
 ====================
@@ -69,11 +70,12 @@ a platform-dependent location:
 * **Linux**: :file:`~/.config/sublime-text-3`
 
 If you're using the **portable version** (Windows only),
-look for :file:`{Sublime Text 3}/Data`.
-Here, *Sublime Text 3*
+look for :file:`{Application}/Data`.
+Here, ``Application``
 refers to the directory
 to which you've extracted
-the compressed portable files.
+the compressed portable files
+and where the executable resides.
 
 Note that the :file:`Data` directory
 only exists with that name
@@ -91,9 +93,9 @@ located under the data directory.
 All resources for supported programming
 and markup languages
 are stored here.
-(More on *packages* and *resources* later.)
 
-.. TODO: link term above to glossary?
+(More on *packages* and *resources* :doc:`later </extensibility/packages>`.)
+
 
 You can access the packages directory
 from the main menu (**Preferences → Browse Packages...**),
@@ -108,12 +110,15 @@ as *Packages*, *packages path*, *packages folder* or *packages directory*.
 The *User* Package
 ******************
 
-:file:`Packages/User` is a catch-all directory
+:file:`{Packages}/User` is a catch-all directory
 for custom plugins, snippets, macros, etc.
 Consider it your personal area
 in the packages folder.
+Additionally, it will contain
+most of your personal application or plugin settings.
+
 Updates to Sublime Text will never
-overwrite the contents of :file:`Packages/User`.
+overwrite the contents of :file:`{Packages}/User`.
 
 
 Sublime Text is Programmable

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -4,6 +4,9 @@
 
 A package is a container for resources.
 
+.. contents::
+   :depth: 3
+
 
 Package Locations (and Abbreviations)
 =====================================
@@ -37,6 +40,41 @@ can optionally be in any number of subdirectories.
    by :file:`{Packages}/PackageName`.
    Consequently, a file inside a package
    may also be referred to as :file:`PackageName/a_file.extension`.
+
+
+.. _.sublime-package:
+
+``.sublime-package`` Packages
+*****************************
+
+Packages inside ``.sublime-package`` zip archives
+are to be considered atomic containers of resources
+and not to be modified manually.
+Since they are usually replaced as a whole,
+any manual changes made to them
+will be lost in the process.
+
+For modifying these archived packages,
+see :ref:`overriding-packages`.
+
+
+Same-Package Interactions
+*************************
+
+If the same package name exists
+in both :file:`{Installed Packages}` and :file:`{Shipped Packages}`,
+the one in :file:`{Installed Packages}` takes precedence
+and the other is ignored.
+
+If the same package name exists
+in :file:`{Packages}` and any other location,
+any files in the :file:`{Packages}` package
+take precedence over their counterpart
+in a ``.sublime-package`` package.
+Files that only exist in the ``.sublime-package`` archive
+are unaffected.
+
+See also :ref:`overriding-packages`.
 
 
 Package Contents
@@ -135,6 +173,19 @@ and you don't need to learn it.
          'copying a ``.sublime-package`` archive
          to :file:`{Installed Packages}`'.
 
+   **override packages**
+      A special type of *user packages*.
+
+      Override packages serve the purpose of customizing packages
+      that are bundled in ``.sublime-package`` files.
+      They are effectively injected into the original package
+      and will usually not be referred to as stand-alone packages.
+
+      See :ref:`overriding-packages` for details.
+
+      Located in :file:`{Packages}`.
+
+
 Note that by *third party*
 we also refer to users of other
 editors, notably Textmate,
@@ -143,8 +194,13 @@ share some types of resource files
 that can be reused without modification.
 
 
+Managing Packages
+=================
+
+.. XXX some sentences here?
+
 Installing Packages
-===================
+*******************
 
 .. note::
 
@@ -171,69 +227,124 @@ in two main ways:
   you can create it.
 
 
-.. _installation-of-sublime-packages:
+Disabling Packages
+******************
 
-Installation of ``.sublime-package`` Archives
-*********************************************
+To temporarily disable packages,
+you can add them to the ``ignored_packages`` list setting
+in your :file:`{Packages}/User/Preferences.sublime-settings` file.
 
-Copy the ``.sublime-package`` archive
-to the ``<Data>/Installed Packages`` folder
-and restart Sublime Text.
-If the ``<Data>/Installed Packages`` folder
-doesn't exist, you can create it.
-
-Note that ``.sublime-package`` files
-are just ``.zip`` archives with a custom file extension.
+Changes are detected when the file is saved
+and packages will be (un-)loaded on the fly.
 
 
-Packages and Magic
-==================
+Removing Packages
+*****************
 
-Sublime Text deals with packages without much hidden magic. There are two
-notable exceptions: Macros defined in any package automatically appear under
-**Tools → Macros → <Your Package>**, and snippets from any package appear
-under **Tools → Snippets → <Your Package>**.
+Firstly, if you installed a package with a package manager
+you should use the method provided by the manager
+to remove it.
 
-However, Sublime Text follows some rules for packages. For instance,
-``Package/User`` will never be clobbered during updates to the software.
+If you installed a package manually,
+it is safest to `disable <#disabling-packages>`_ the package
+and then remove the package's resources from the disk
+while Sublime Text is not running.
+Afterwards you can re-enable the package
+since it doesn't exist anymore.
 
-.. sidebar:: The ``User`` Package
+In addition to the resources
+you have placed initially in a :file:`Packages` folder,
+plugins may create configuration files
+(such as ``.sublime-settings`` files)
+or other files to store package-related data.
+Usually you will find them in the *User* package.
+When you want to remove all traces of a package
+you need to remove these files manually.
 
-   Usually, unpackaged resources are stored in ``Packages/User``. If you
-   have a few loose snippets, macros or plugins, this is a good place to keep
-   them.
+.. warning::
+
+   Do not attempt to remove :term:`shipped packages`;
+   they will be re-added on every Sublime Text update!
+   Disable them instead.
+
+
+.. _overriding-packages:
+
+Customizing or Overriding Packages
+==================================
+
+Since packages in ``.sublime-package`` zip archives
+:ref:`are atomic <.sublime-package>`,
+you can not modify them directly.
+However, Sublime Text allows you
+to create an :term:`override package <override packages>`
+that will effectively inject files into the original archive
+without changing the actual file.
+
+To create an override package package,
+just create a new folder under :file:`{Packages}`
+and name it after the ``.sublime-package`` file
+you want to override, without the extension.
+Any file you create in this package
+will take precedence over a potential counterpart file
+in the original package.
+
+Python plugins are able to use relative imports
+for accessing other modules in the ``.sublime-package`` file
+as if they were part of it.
+
+.. warning::
+
+   Since you are always overriding entire files
+   you will not receive any updates for these overridden files
+   if the original ``.sublime-package`` happens to be updated
+   at some point.
+
+.. Generally, this only works on resources
+   interpreted by Sublime Text directly.
+   If there are other files which the package loads
+   by means of a Python plugin,
+   it depends on whether the code uses
+   the ``sublime.load_resource`` API or not.
 
 
 .. _merging-and-order-of-precedence:
 
 Merging and Order of Precedence
-*******************************
+===============================
 
-*Packages/Default* and *Packages/User* receive special treatment when
-merging files (e.g. *.sublime-keymap* and *.sublime-settings* files).
-Before merging can take place, the files have to be arranged in some order. To
-that end, Sublime Text sorts them alphabetically by name, with the exception
-of the *Default* and *User* folders. Files contained in *Default* will
-always go to the front of the list, and those in *User*, to the end.
+Package precedence is important for merging certain resources
+(e.g. ``.sublime-keymap`` and ``.sublime-settings`` files)
+or loading plugins (``.py``).
 
+If an :term:`override package <override packages>` exists
+for a ``.sublime-package`` package,
+it will be loaded together with the ``.sublime-package`` package.
 
-Ignored Packages
-================
-
-To temporarily disable packages,
-you can add them to the ``ignored_packages`` list
-in your ``Packages/User/Preferences.sublime-settings`` file.
+1. :file:`{Packages}/Default` is loaded.
+#. All :term:`shipped packages` and :term:`installed packages`
+   are joined and loaded in alphabetical order.
+#. All remaining :term:`user packages`
+   that did not override anything
+   are loaded in alphabetical order.
+#. :file:`{Packages}/User` is loaded.
 
 
 Reverting Sublime Text to Its Default Configuration
 ===================================================
 
-To revert Sublime Text to its default configuration, delete the data directory
-and restart the editor. Keep in mind that the ``Installed Packages`` folder will
-be deleted too, so you'll lose all your installed packages.
+To revert Sublime Text to its default configuration
+and remove all your settings and configurations,
+delete the :ref:`data directory <data-directory>`
+and restart the editor.
+Keep in mind
+that the ``Installed Packages`` folder will be deleted too,
+so you'll lose all your installed packages.
 
-Always make sure to back up your data before taking an extreme measure like
-this one.
+Always make sure to back up your data
+before taking an extreme measure like this one.
 
-Reverting Sublime Text to a fresh state solves many problems that appear to be
-due to bugs in Sublime Text but are in fact caused by misbehaving plugins.
+Reverting Sublime Text to a fresh state
+solves many problems
+that appear to be bugs in Sublime Text
+but are in fact caused by misbehaving plugins.

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -22,19 +22,21 @@ for different purposes.
   as **zip archives**
   in :file:`{Application}/Packages` (short: :file:`{Shipped Packages}`),
   where ``Application`` refers to the folder
-  that the ST binary resides in.
+  that the Sublime Text executable resides.
 
 Zip archives in :file:`{Installed Packages}`
 (or :file:`{Shipped Packages}`)
 can optionally be in any number of subdirectories.
 
-For simplicity we will, on occasions,
-collectively refer to all these directories by :file:`{Packages}`
-and refer to a package in any folder
-(``.sublime-package`` or not)
-by :file:`{Packages}/Package Name`.
-Consequently, a file inside a package
-may also be referred to as :file:`{Package Name}/a_file.extension`.
+.. note::
+
+   For simplicity we will, on occasions,
+   collectively refer to all these directories by :file:`{Packages}`
+   and refer to a package in any folder
+   (``.sublime-package`` or not)
+   by :file:`{Packages}/PackageName`.
+   Consequently, a file inside a package
+   may also be referred to as :file:`PackageName/a_file.extension`.
 
 
 Package Contents
@@ -74,58 +76,64 @@ for clarity when discussing this topic.
 Sublime Text doesn't use this terminology
 and you don't need to learn it.
 
-**shipped packages** (or *default packages*)
-   A set of packages
-   that Sublime Text ships with by default.
-   They are included in every installation,
-   though technically not required
-   and enhance Sublime Text out of the box.
+.. glossary::
 
-   Examples: Default, Python, Java, C++, Markdown
+   **shipped packages**
+   **default packages**
+      A set of packages
+      that Sublime Text ships with by default.
+      They are included in every installation,
+      though technically not required,
+      and enhance Sublime Text out of the box.
 
-   Located in :file:`{Shipped Packages}`.
+      Examples: Default, Python, Java, C++, Markdown
 
-**core packages**
-   Sublime Text requires these packages
-   in order to function properly.
+      Located in :file:`{Shipped Packages}`.
 
-   Examples: Default, Theme - Default, Color Scheme - Default
+   **core packages**
+      Sublime Text requires these packages
+      in order to function properly.
 
-   They are part of the shipped packages and
-   located in :file:`{Shipped Packages}`.
+      Examples: Default, Theme - Default, Color Scheme - Default
 
-**user packages**
-   Installed or created by the user
-   to extend Sublime Text's functionality.
-   They are not part of Sublime Text,
-   and are always contributed by users
-   or third parties.
+      They are part of the shipped packages and
+      located in :file:`{Shipped Packages}`.
 
-   Example: User
+   **user packages**
+      Installed or created by the user
+      to extend Sublime Text's functionality.
+      They are not part of Sublime Text,
+      and are always contributed by users
+      or third parties.
 
-   Located in :file:`{Packages}`
-   and :file:`{Installed Packages}`.
+      Example: User
 
-**installed packages**
-   A subtype of *user packages*.
+      Located in :file:`{Packages}`
+      and :file:`{Installed Packages}`.
 
-   Packages stored under :file:`{Installed Packages}`
-   as ``.sublime-package`` archives.
+   **installed packages**
+      A subtype of *user packages*.
 
-   .. note::
+      Installed packages are ``.sublime-package``
+      and usually maintained by a package manager of some sort.
 
-      Due to the unfortunate name of this folder,
-      talking about *installing*
-      packages in Sublime Text
-      becomes a confusing business.
+      Packages stored under :file:`{Installed Packages}`
+      as ``.sublime-package`` archives.
 
-      Sometimes, in this guide, by *installing* we mean
-      'adding a user/third party package to Sublime Text'
-      (in any form),
-      and sometimes we use the term
-      in its stricter sense of
-      'copying a ``.sublime-package`` archive
-      to :file:`{Installed Packages}`'.
+      .. note::
+
+         Due to the unfortunate name of this folder,
+         talking about *installing*
+         packages in Sublime Text
+         becomes a confusing business.
+
+         Sometimes, in this guide, by *installing* we mean
+         'adding a user/third party package to Sublime Text'
+         (in any form),
+         and sometimes we use the term
+         in its stricter sense of
+         'copying a ``.sublime-package`` archive
+         to :file:`{Installed Packages}`'.
 
 Note that by *third party*
 we also refer to users of other
@@ -146,25 +154,21 @@ Installing Packages
    as automatic package managers
    are available.
 
-   The de facto package manager
+   The de-facto package manager
    for Sublime Text is `Package Control`_.
 
-.. _Package Control: https://packagecontrol.io
+   .. _Package Control: https://packagecontrol.io
+
 
 Packages can be installed
 in two main ways:
 
 - by copying Sublime Text resources
-  to a folder under ``Packages``, or
+  to a (new) folder under :file:`{Packages}`, or
 - by copying a ``.sublime-package`` file
-  to :file:`{Installed Packages}`
-
-.. note::
-
-   In this guide,
-   *installed packages* sometimes refers strictly
-   to ``.sublime-package`` archives residing
-   in the :file:`<Data>/Installed Packages` directory.
+  to :file:`{Installed Packages}`.
+  If the folder does not exist
+  you can create it.
 
 
 .. _installation-of-sublime-packages:
@@ -221,18 +225,8 @@ you can add them to the ``ignored_packages`` list
 in your ``Packages/User/Preferences.sublime-settings`` file.
 
 
-Restoring Packages
-==================
-
-Sublime Text keeps a copy of all installed packages so it can recreate them as
-needed. This means it can reinstall core packages, shipped packages and,
-potentially, user packages alike. However, only user packages installed as
-``sublime-packages`` are added to its registry of installed packages. Packages
-installed in alternative ways will be lost completely if you delete them.
-
-
 Reverting Sublime Text to Its Default Configuration
-***************************************************
+===================================================
 
 To revert Sublime Text to its default configuration, delete the data directory
 and restart the editor. Keep in mind that the ``Installed Packages`` folder will

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -3,9 +3,42 @@
 ==========
 
 A package is a container for resources.
-Packages can be folders under ``Packages``,
-or zip archives under ``<Data>/Installed Packages``
-with the ``.sublime-package`` extension.
+
+
+Package Locations (and Abbreviations)
+=====================================
+
+There are three locations
+for storing packages
+for different purposes.
+
+- Packages can be **folders**
+  under :file:`{Data}/Packages` (short: :file:`{Packages}`)
+- or **zip archives**
+  under :file:`{Data}/Installed Packages` (short: :file:`{Installed Packages}`)
+  with the ``.sublime-package`` extension.
+- Additionally,
+  Sublime Text provides a set of default packages
+  as **zip archives**
+  in :file:`{Application}/Packages` (short: :file:`{Shipped Packages}`),
+  where ``Application`` refers to the folder
+  that the ST binary resides in.
+
+Zip archives in :file:`{Installed Packages}`
+(or :file:`{Shipped Packages}`)
+can optionally be in any number of subdirectories.
+
+For simplicity we will, on occasions,
+collectively refer to all these directories by :file:`{Packages}`
+and refer to a package in any folder
+(``.sublime-package`` or not)
+by :file:`{Packages}/Package Name`.
+Consequently, a file inside a package
+may also be referred to as :file:`{Package Name}/a_file.extension`.
+
+
+Package Contents
+================
 
 Typical resources found in packages include:
 
@@ -29,16 +62,8 @@ Typical resources found in packages include:
 Some packages may hold support files
 for other packages or core features.
 For example, the spell checker
-uses ``Packages/Language - English.sublime-package``
+uses :file:`{Installed Packages}/Language - English.sublime-package`
 as a data store for English dictionaries.
-
-
-The *Installed Packages* Folder
-===============================
-
-You will find this folder
-in ``<Data>/Installed Packages``.
-It contains ``.sublime-package`` archives.
 
 
 Types of Packages
@@ -49,18 +74,25 @@ for clarity when discussing this topic.
 Sublime Text doesn't use this terminology
 and you don't need to learn it.
 
+**shipped packages** (or *default packages*)
+   A set of packages
+   that Sublime Text ships with by default.
+   They are included in every installation,
+   though technically not required
+   and enhance Sublime Text out of the box.
+
+   Examples: Default, Python, Java, C++, Markdown
+
+   Located in :file:`{Shipped Packages}`.
+
 **core packages**
    Sublime Text requires these packages
    in order to function properly.
-   Located in ``<Data>/../Packages``.
 
-**shipped packages**
-   Included in every installation,
-   though technically not required.
-   They enhance Sublime Text out of the box.
-   May have been contributed by users or
-   third parties.
-   Located in ``<Data>/../Packages``.
+   Examples: Default, Theme - Default, Color Scheme - Default
+
+   They are part of the shipped packages and
+   located in :file:`{Shipped Packages}`.
 
 **user packages**
    Installed or created by the user
@@ -68,13 +100,17 @@ and you don't need to learn it.
    They are not part of Sublime Text,
    and are always contributed by users
    or third parties.
-   Located in ``<Data>/Packages``
-   and ``<Data>/Installed Packages``.
+
+   Example: User
+
+   Located in :file:`{Packages}`
+   and :file:`{Installed Packages}`.
 
 **installed packages**
-   Packages stored under
-   ``<Data>/Installed Packages`` as ``.sublime-package`` archives.
-   A type of *user package*.
+   A subtype of *user packages*.
+
+   Packages stored under :file:`{Installed Packages}`
+   as ``.sublime-package`` archives.
 
    .. note::
 
@@ -89,7 +125,7 @@ and you don't need to learn it.
       and sometimes we use the term
       in its stricter sense of
       'copying a ``.sublime-package`` archive
-      to ``<Data>/Installed Packages``'.
+      to :file:`{Installed Packages}`'.
 
 Note that by *third party*
 we also refer to users of other
@@ -121,7 +157,7 @@ in two main ways:
 - by copying Sublime Text resources
   to a folder under ``Packages``, or
 - by copying a ``.sublime-package`` file
-  to ``<Data>/Installed Packages``
+  to :file:`{Installed Packages}`
 
 .. note::
 
@@ -151,8 +187,8 @@ Packages and Magic
 
 Sublime Text deals with packages without much hidden magic. There are two
 notable exceptions: Macros defined in any package automatically appear under
-**Tools ? Macros ? <Your Package>**, and snippets from any package appear
-under **Tools ? Snippets ? <Your Package>**.
+**Tools → Macros → <Your Package>**, and snippets from any package appear
+under **Tools → Snippets → <Your Package>**.
 
 However, Sublime Text follows some rules for packages. For instance,
 ``Package/User`` will never be clobbered during updates to the software.

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -18,9 +18,10 @@ for different purposes.
 - Packages can be **folders**
   under :file:`{Data}/Packages` (short: :file:`{Packages}`)
 - or **zip archives**
-  under :file:`{Data}/Installed Packages` (short: :file:`{Installed Packages}`),
-  or any subdirectory under it,
-  with the ``.sublime-package`` extension.
+  with the ``.sublime-package`` extension
+  located under :file:`{Data}/Installed Packages`
+  (short: :file:`{Installed Packages}`)
+  or any of its subdirectories.
 - Additionally,
   Sublime Text provides a set of default packages
   as **zip archives**
@@ -62,8 +63,8 @@ Interactions Between Packages With the Same Name
 
 If two packages with the same name exist
 in both :file:`{Installed Packages}` and :file:`{Shipped Packages}`,
-the one in :file:`{Installed Packages}` will take precedence
-and the other is will be ignored.
+the one in :file:`{Installed Packages}` will be used
+and the other ignored.
 
 Any files in :file:`{Packages}` take precedence
 over their counterpart files in a ``.sublime-package`` package
@@ -174,7 +175,7 @@ and you don't need to learn it.
       Override packages serve the purpose of customizing packages
       that are distributed as ``.sublime-package`` files.
       They are effectively injected into the original package
-      do not stand-alone.
+      and do not stand-alone.
 
       See :ref:`overriding-packages` for details.
 
@@ -255,7 +256,7 @@ follow this procedure to safely remove a package:
    while Sublime Text is running.
 #. Close Sublime Text.
 #. Remove the package's resources from the disk.
-4. Finally you can remove the package
+4. Finally, you can remove the package
    from the ``ignored_packages`` list setting,
    since it doesn't exist anymore.
 
@@ -325,7 +326,7 @@ Merging and Order of Precedence
 
 Package precedence is important for merging certain resources,
 for example, ``.sublime-keymap`` and ``.sublime-settings`` files,
-or loading plugins (``.py``).
+or for loading plugins (``.py``).
 
 If an :term:`override package <override packages>` exists
 for a ``.sublime-package`` package,

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -51,7 +51,7 @@ and you don't need to learn it.
 
 **core packages**
    Sublime Text requires these packages
-   in order to work.
+   in order to function properly.
    Located in ``<Data>/../Packages``.
 
 **shipped packages**
@@ -63,8 +63,8 @@ and you don't need to learn it.
    Located in ``<Data>/../Packages``.
 
 **user packages**
-   Installed by the user
-   to extend Sublime Text's functionaility.
+   Installed or created by the user
+   to extend Sublime Text's functionality.
    They are not part of Sublime Text,
    and are always contributed by users
    or third parties.
@@ -83,7 +83,7 @@ and you don't need to learn it.
       packages in Sublime Text
       becomes a confusing business.
 
-      Sometimes, in this guide, by *instaling* we mean
+      Sometimes, in this guide, by *installing* we mean
       'adding a user/third party package to Sublime Text'
       (in any form),
       and sometimes we use the term
@@ -92,8 +92,8 @@ and you don't need to learn it.
       to ``<Data>/Installed Packages``'.
 
 Note that by *third party*
-we mainly refer to users of other
-editors, such as Textmate,
+we also refer to users of other
+editors, notably Textmate,
 as Sublime Text and Textmate
 share some types of resource files
 that can be reused without modification.
@@ -111,14 +111,16 @@ Installing Packages
    are available.
 
    The de facto package manager
-   for Sublime Text is Package Control.
+   for Sublime Text is `Package Control`_.
+
+.. _Package Control: https://packagecontrol.io
 
 Packages can be installed
 in two main ways:
 
 - by copying Sublime Text resources
-  to  a folder under ``Packages``, or
-- by copying a ``.sublime-package``
+  to a folder under ``Packages``, or
+- by copying a ``.sublime-package`` file
   to ``<Data>/Installed Packages``
 
 .. note::

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -1,6 +1,6 @@
-========
-Packages
-========
+==========
+ Packages
+==========
 
 A package is a container for resources.
 Packages can be folders under ``Packages``,
@@ -30,7 +30,7 @@ as a data store for English dictionaries.
 
 
 The *Installed Packages* Folder
-*******************************
+===============================
 
 You will find this folder
 in ``<Data>/Installed Packages``.
@@ -38,7 +38,7 @@ It contains ``.sublime-package`` archives.
 
 
 Types of Packages
-*****************
+=================
 
 In this guide, we categorize packages
 for clarity when discussing this topic.
@@ -96,7 +96,7 @@ that can be reused without modification.
 
 
 Installing Packages
-*******************
+===================
 
 .. note::
 
@@ -128,7 +128,7 @@ in two main ways:
 .. _installation-of-sublime-packages:
 
 Installation of ``.sublime-package`` Archives
----------------------------------------------
+*********************************************
 
 Copy the ``.sublime-package`` archive
 to the ``<Data>/Installed Packages`` folder
@@ -141,12 +141,12 @@ are just ``.zip`` archives with a custom file extension.
 
 
 Packages and Magic
-******************
+==================
 
 Sublime Text deals with packages without much hidden magic. There are two
 notable exceptions: Macros defined in any package automatically appear under
-**Tools | Macros | <Your Package>**, and snippets from any package appear
-under **Tools | Snippets | <Your Package>**.
+**Tools ? Macros ? <Your Package>**, and snippets from any package appear
+under **Tools ? Snippets ? <Your Package>**.
 
 However, Sublime Text follows some rules for packages. For instance,
 ``Package/User`` will never be clobbered during updates to the software.
@@ -161,7 +161,7 @@ However, Sublime Text follows some rules for packages. For instance,
 .. _merging-and-order-of-precedence:
 
 Merging and Order of Precedence
--------------------------------
+*******************************
 
 *Packages/Default* and *Packages/User* receive special treatment when
 merging files (e.g. *.sublime-keymap* and *.sublime-settings* files).
@@ -172,7 +172,7 @@ always go to the front of the list, and those in *User*, to the end.
 
 
 Ignored Packages
-****************
+================
 
 To temporarily disable packages,
 you can add them to the ``ignored_packages`` list
@@ -180,7 +180,7 @@ in your ``Packages/User/Preferences.sublime-settings`` file.
 
 
 Restoring Packages
-******************
+==================
 
 Sublime Text keeps a copy of all installed packages so it can recreate them as
 needed. This means it can reinstall core packages, shipped packages and,
@@ -190,7 +190,7 @@ installed in alternative ways will be lost completely if you delete them.
 
 
 Reverting Sublime Text to Its Default Configuration
----------------------------------------------------
+***************************************************
 
 To revert Sublime Text to its default configuration, delete the data directory
 and restart the editor. Keep in mind that the ``Installed Packages`` folder will

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -12,15 +12,19 @@ Typical resources found in packages include:
 .. hlist::
 
    - build systems (``.sublime-build``)
+   - color schemes (``.tmTheme``)
    - key maps (``.sublime-keymap``)
    - macros (``.sublime-macro``)
    - menus (``.sublime-menu``)
+   - metadata (``.tmPreferences``)
+   - mouse maps (``.sublime-mousemap``)
    - plugins (``.py``)
    - settings (``.sublime-settings``)
    - snippets (``.sublime-snippet``)
    - syntax definitions (``.tmLanguage``)
-   - metadata (``.tmPreferences``)
    - themes (``.sublime-theme``)
+
+.. XXX link to respective docs
 
 Some packages may hold support files
 for other packages or core features.

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -20,24 +20,22 @@ for different purposes.
 - or **zip archives**
   under :file:`{Data}/Installed Packages` (short: :file:`{Installed Packages}`)
   with the ``.sublime-package`` extension.
+  Archives can optionally be in any number of subdirectories.
 - Additionally,
   Sublime Text provides a set of default packages
   as **zip archives**
   in :file:`{Application}/Packages` (short: :file:`{Shipped Packages}`),
   where ``Application`` refers to the folder
   that the Sublime Text executable resides.
-
-Zip archives in :file:`{Installed Packages}`
-(or :file:`{Shipped Packages}`)
-can optionally be in any number of subdirectories.
+  The folder is not intended to be modified by the user.
 
 .. note::
 
-   For simplicity we will, on occasions,
-   collectively refer to all these directories by :file:`{Packages}`
-   and refer to a package in any folder
+   For simplicity, we will occasionally
+   refer to all these directories simply as :file:`{Packages}`
+   and to a package in any folder
    (``.sublime-package`` or not)
-   by :file:`{Packages}/PackageName`.
+   as :file:`{Packages}/PackageName`.
    Consequently, a file inside a package
    may also be referred to as :file:`PackageName/a_file.extension`.
 
@@ -48,31 +46,27 @@ can optionally be in any number of subdirectories.
 *****************************
 
 Packages inside ``.sublime-package`` zip archives
-are to be considered atomic containers of resources
-and not to be modified manually.
-Since they are usually replaced as a whole,
+should be considered read-only containers of resources
+and should never modified manually.
+Since they are usually updated as a whole,
 any manual changes made to them
 will be lost in the process.
 
-For modifying these archived packages,
+If you do want to modify files in these archives,
 see :ref:`overriding-packages`.
 
 
-Same-Package Interactions
-*************************
+Interactions Between Packages With the Same Name
+************************************************
 
-If the same package name exists
+If two packages with the same name exist
 in both :file:`{Installed Packages}` and :file:`{Shipped Packages}`,
 the one in :file:`{Installed Packages}` takes precedence
-and the other is ignored.
+and the other is ignored entirely.
 
-If the same package name exists
-in :file:`{Packages}` and any other location,
-any files in the :file:`{Packages}` package
-take precedence over their counterpart
-in a ``.sublime-package`` package.
-Files that only exist in the ``.sublime-package`` archive
-are unaffected.
+Any files in :file:`{Packages}` take precedence
+over their counterpart files in a ``.sublime-package`` package
+or are simply added to the package.
 
 See also :ref:`overriding-packages`.
 
@@ -98,6 +92,7 @@ Typical resources found in packages include:
    - themes (``.sublime-theme``)
 
 .. XXX link to respective docs
+.. XXX add secondary extensions (.tmSnippet, .sublime-syntax)
 
 Some packages may hold support files
 for other packages or core features.
@@ -119,10 +114,10 @@ and you don't need to learn it.
    **shipped packages**
    **default packages**
       A set of packages
-      that Sublime Text ships with by default.
-      They are included in every installation,
-      though technically not required,
-      and enhance Sublime Text out of the box.
+      that Sublime Text ships with.
+      Some of these packages are :term:`core packages`
+      while others enhance Sublime Text
+      to support common programming languages out of the box.
 
       Examples: Default, Python, Java, C++, Markdown
 
@@ -155,8 +150,7 @@ and you don't need to learn it.
       Installed packages are ``.sublime-package``
       and usually maintained by a package manager of some sort.
 
-      Packages stored under :file:`{Installed Packages}`
-      as ``.sublime-package`` archives.
+      Located in :file:`{Installed Packages}`.
 
       .. note::
 
@@ -177,9 +171,9 @@ and you don't need to learn it.
       A special type of *user packages*.
 
       Override packages serve the purpose of customizing packages
-      that are bundled in ``.sublime-package`` files.
+      that are packed as ``.sublime-package`` files.
       They are effectively injected into the original package
-      and will usually not be referred to as stand-alone packages.
+      and not stand-alone.
 
       See :ref:`overriding-packages` for details.
 
@@ -206,11 +200,11 @@ Installing Packages
 
    Nowadays, regular users
    rarely need to know
-   how to install packages by hand,
+   how to install packages by hand
    as automatic package managers
    are available.
 
-   The de-facto package manager
+   The de facto package manager
    for Sublime Text is `Package Control`_.
 
    .. _Package Control: https://packagecontrol.io
@@ -220,12 +214,12 @@ Packages can be installed
 in two main ways:
 
 - by copying Sublime Text resources
-  to a (new) folder under :file:`{Packages}`, or
+  to a folder under :file:`{Packages}`, or
 - by copying a ``.sublime-package`` file
   to :file:`{Installed Packages}`.
-  If the folder does not exist
-  you can create it.
 
+
+.. _disabling-packages:
 
 Disabling Packages
 ******************
@@ -235,37 +229,50 @@ you can add them to the ``ignored_packages`` list setting
 in your :file:`{Packages}/User/Preferences.sublime-settings` file.
 
 Changes are detected when the file is saved
-and packages will be (un-)loaded on the fly.
+and packages will be loaded or unloaded on the fly.
+
+
+Enabling Packages
+*****************
+
+Similarly to :ref:`disabling-packages`,
+enabling a package is simply a matter of
+removing the package's name from the ``ignored_packages`` list setting.
 
 
 Removing Packages
 *****************
 
-Firstly, if you installed a package with a package manager
+If you installed a package with a package manager
 you should use the method provided by the manager
 to remove it.
 
 If you installed a package manually,
-it is safest to `disable <#disabling-packages>`_ the package
-and then remove the package's resources from the disk
-while Sublime Text is not running.
-Afterwards you can re-enable the package
-since it doesn't exist anymore.
+follow this procedure to safely remove a package:
+
+1. :ref:`Disable <disabling-packages>` the package
+   while Sublime Text is running.
+#. Close Sublime Text.
+#. Remove the package's resources from the disk.
+4. Afterwards you can remove the package
+   from the ``ignored_packages`` list setting
+   since it doesn't exist anymore.
 
 In addition to the resources
-you have placed initially in a :file:`Packages` folder,
+you have placed initially
+in a :file:`{Packages}` folder or in :file:`{Installed Packages}`,
 plugins may create configuration files
 (such as ``.sublime-settings`` files)
 or other files to store package-related data.
-Usually you will find them in the *User* package.
-When you want to remove all traces of a package
-you need to remove these files manually.
+Usually, you will find them in the *User* package.
+If you want to remove all traces of a package
+you need to find and remove these files manually.
 
 .. warning::
 
-   Do not attempt to remove :term:`shipped packages`;
-   they will be re-added on every Sublime Text update!
-   Disable them instead.
+   Shipped Packages are reinstated on every Sublime Text update.
+   If you want to get rid of any of them,
+   :ref:`disable <disabling-packages>` them instead of deleting.
 
 
 .. _overriding-packages:
@@ -274,14 +281,14 @@ Customizing or Overriding Packages
 ==================================
 
 Since packages in ``.sublime-package`` zip archives
-:ref:`are atomic <.sublime-package>`,
+:ref:`are read-only <.sublime-package>`,
 you can not modify them directly.
 However, Sublime Text allows you
 to create an :term:`override package <override packages>`
 that will effectively inject files into the original archive
-without changing the actual file.
+without changing the archive file.
 
-To create an override package package,
+To create an override package,
 just create a new folder under :file:`{Packages}`
 and name it after the ``.sublime-package`` file
 you want to override, without the extension.
@@ -289,13 +296,14 @@ Any file you create in this package
 will take precedence over a potential counterpart file
 in the original package.
 
-Python plugins are able to use relative imports
+Python plugins in override packages
+are able to use relative imports
 for accessing other modules in the ``.sublime-package`` file
 as if they were part of it.
 
 .. warning::
 
-   Since you are always overriding entire files
+   Since you are always overriding entire files,
    you will not receive any updates for these overridden files
    if the original ``.sublime-package`` happens to be updated
    at some point.
@@ -305,7 +313,8 @@ as if they were part of it.
    If there are other files which the package loads
    by means of a Python plugin,
    it depends on whether the code uses
-   the ``sublime.load_resource`` API or not.
+   the ``sublime.load_resource`` API or not
+   (which they should).
 
 
 .. _merging-and-order-of-precedence:
@@ -314,7 +323,7 @@ Merging and Order of Precedence
 ===============================
 
 Package precedence is important for merging certain resources
-(e.g. ``.sublime-keymap`` and ``.sublime-settings`` files)
+(for example ``.sublime-keymap`` and ``.sublime-settings`` files)
 or loading plugins (``.py``).
 
 If an :term:`override package <override packages>` exists
@@ -326,12 +335,17 @@ it will be loaded together with the ``.sublime-package`` package.
    are joined and loaded in alphabetical order.
 #. All remaining :term:`user packages`
    that did not override anything
-   are loaded in alphabetical order.
+   are loaded in alphabetical order,
+   except for :file:`{Packages}/User`.
 #. :file:`{Packages}/User` is loaded.
 
 
 Reverting Sublime Text to Its Default Configuration
 ===================================================
+
+Because of the nature of a powerful scripting language like Python,
+packages may cause Sublime Text to not function properly
+or have bad interactions between one another.
 
 To revert Sublime Text to its default configuration
 and remove all your settings and configurations,

--- a/source/extensibility/packages.rst
+++ b/source/extensibility/packages.rst
@@ -18,16 +18,17 @@ for different purposes.
 - Packages can be **folders**
   under :file:`{Data}/Packages` (short: :file:`{Packages}`)
 - or **zip archives**
-  under :file:`{Data}/Installed Packages` (short: :file:`{Installed Packages}`)
+  under :file:`{Data}/Installed Packages` (short: :file:`{Installed Packages}`),
+  or any subdirectory under it,
   with the ``.sublime-package`` extension.
-  Archives can optionally be in any number of subdirectories.
 - Additionally,
   Sublime Text provides a set of default packages
   as **zip archives**
   in :file:`{Application}/Packages` (short: :file:`{Shipped Packages}`),
   where ``Application`` refers to the folder
   that the Sublime Text executable resides.
-  The folder is not intended to be modified by the user.
+
+  This folder is not intended to be modified by the user.
 
 .. note::
 
@@ -45,9 +46,9 @@ for different purposes.
 ``.sublime-package`` Packages
 *****************************
 
-Packages inside ``.sublime-package`` zip archives
+Packages distributed as ``.sublime-package`` zip archives
 should be considered read-only containers of resources
-and should never modified manually.
+and never be modified manually.
 Since they are usually updated as a whole,
 any manual changes made to them
 will be lost in the process.
@@ -61,8 +62,8 @@ Interactions Between Packages With the Same Name
 
 If two packages with the same name exist
 in both :file:`{Installed Packages}` and :file:`{Shipped Packages}`,
-the one in :file:`{Installed Packages}` takes precedence
-and the other is ignored entirely.
+the one in :file:`{Installed Packages}` will take precedence
+and the other is will be ignored.
 
 Any files in :file:`{Packages}` take precedence
 over their counterpart files in a ``.sublime-package`` package
@@ -115,7 +116,7 @@ and you don't need to learn it.
    **default packages**
       A set of packages
       that Sublime Text ships with.
-      Some of these packages are :term:`core packages`
+      Some of these packages are :term:`core packages`,
       while others enhance Sublime Text
       to support common programming languages out of the box.
 
@@ -147,8 +148,8 @@ and you don't need to learn it.
    **installed packages**
       A subtype of *user packages*.
 
-      Installed packages are ``.sublime-package``
-      and usually maintained by a package manager of some sort.
+      Installed packages are ``.sublime-package`` archives
+      and usually maintained by a package manager.
 
       Located in :file:`{Installed Packages}`.
 
@@ -171,9 +172,9 @@ and you don't need to learn it.
       A special type of *user packages*.
 
       Override packages serve the purpose of customizing packages
-      that are packed as ``.sublime-package`` files.
+      that are distributed as ``.sublime-package`` files.
       They are effectively injected into the original package
-      and not stand-alone.
+      do not stand-alone.
 
       See :ref:`overriding-packages` for details.
 
@@ -200,7 +201,7 @@ Installing Packages
 
    Nowadays, regular users
    rarely need to know
-   how to install packages by hand
+   how to install packages by hand,
    as automatic package managers
    are available.
 
@@ -236,15 +237,15 @@ Enabling Packages
 *****************
 
 Similarly to :ref:`disabling-packages`,
-enabling a package is simply a matter of
+enabling a package is a matter of
 removing the package's name from the ``ignored_packages`` list setting.
 
 
 Removing Packages
 *****************
 
-If you installed a package with a package manager
-you should use the method provided by the manager
+If you installed a package with a package manager,
+you should use the method provided by the package manager
 to remove it.
 
 If you installed a package manually,
@@ -254,8 +255,8 @@ follow this procedure to safely remove a package:
    while Sublime Text is running.
 #. Close Sublime Text.
 #. Remove the package's resources from the disk.
-4. Afterwards you can remove the package
-   from the ``ignored_packages`` list setting
+4. Finally you can remove the package
+   from the ``ignored_packages`` list setting,
    since it doesn't exist anymore.
 
 In addition to the resources
@@ -265,7 +266,7 @@ plugins may create configuration files
 (such as ``.sublime-settings`` files)
 or other files to store package-related data.
 Usually, you will find them in the *User* package.
-If you want to remove all traces of a package
+If you want to remove all traces of a package,
 you need to find and remove these files manually.
 
 .. warning::
@@ -322,8 +323,8 @@ as if they were part of it.
 Merging and Order of Precedence
 ===============================
 
-Package precedence is important for merging certain resources
-(for example ``.sublime-keymap`` and ``.sublime-settings`` files)
+Package precedence is important for merging certain resources,
+for example, ``.sublime-keymap`` and ``.sublime-settings`` files,
 or loading plugins (``.py``).
 
 If an :term:`override package <override packages>` exists
@@ -343,7 +344,7 @@ it will be loaded together with the ``.sublime-package`` package.
 Reverting Sublime Text to Its Default Configuration
 ===================================================
 
-Because of the nature of a powerful scripting language like Python,
+For various reasons,
 packages may cause Sublime Text to not function properly
 or have bad interactions between one another.
 
@@ -356,7 +357,7 @@ that the ``Installed Packages`` folder will be deleted too,
 so you'll lose all your installed packages.
 
 Always make sure to back up your data
-before taking an extreme measure like this one.
+before taking an extreme measure like this one!
 
 Reverting Sublime Text to a fresh state
 solves many problems

--- a/source/glossary/glossary.rst
+++ b/source/glossary/glossary.rst
@@ -1,8 +1,8 @@
 .. _glossary:
 
-========
-Glossary
-========
+==========
+ Glossary
+==========
 
 .. glossary::
 
@@ -15,7 +15,7 @@ Glossary
       Graphical display of a buffer. Multiple views can show the same buffer.
 
    plugin
-      A feature impemented in Python, which can consist of a single command
+      A feature implemented in Python, which can consist of a single command
       or multiple commands. It can be contained in one *.py* file or many
       *.py* files.
 
@@ -38,3 +38,10 @@ Glossary
 
       However, this is an ambiguous term, and in some instances it could also
       be used with the broader meaning it has in technical texts.
+
+.. in extensibility/packages.rst:
+   default packages
+   shipped packages
+   core packages
+   user packages
+   installed packages

--- a/source/glossary/glossary.rst
+++ b/source/glossary/glossary.rst
@@ -45,3 +45,4 @@
    core packages
    user packages
    installed packages
+   override packages

--- a/source/glossary/glossary.rst
+++ b/source/glossary/glossary.rst
@@ -6,35 +6,35 @@ Glossary
 
 .. glossary::
 
-    buffer
-        Data of a loaded file and additional metadata, associated with one or
-        more views. The distinction between *buffer* and *view* is technical.
-        Most of the time, both terms can be used interchangeably.
+   buffer
+      Data of a loaded file and additional metadata, associated with one or
+      more views. The distinction between *buffer* and *view* is technical.
+      Most of the time, both terms can be used interchangeably.
 
-    view
-        Graphical display of a buffer. Multiple views can show the same buffer.
+   view
+      Graphical display of a buffer. Multiple views can show the same buffer.
 
-    plugin
-        A feature impemented in Python, which can consist of a single command
-        or multiple commands. It can be contained in one *.py* file or many
-        *.py* files.
+   plugin
+      A feature impemented in Python, which can consist of a single command
+      or multiple commands. It can be contained in one *.py* file or many
+      *.py* files.
 
-    package
-        This term is ambiguous in the context of Sublime Text, because it can
-        refer to a Python package (unlikely), a folder inside ``Packages``
-        or a *.sublime-package* file. Most of the time, it means a folder
-        inside ``Packages`` containing resources that belong together, which build
-        a new feature or provide support for a programming or markup language.
+   package
+      This term is ambiguous in the context of Sublime Text, because it can
+      refer to a Python package (unlikely), a folder inside ``Packages``
+      or a *.sublime-package* file. Most of the time, it means a folder
+      inside ``Packages`` containing resources that belong together, which build
+      a new feature or provide support for a programming or markup language.
 
-    panel
-        An input/output widget, such as a search panel or the output panel.
+   panel
+      An input/output widget, such as a search panel or the output panel.
 
-    overlay
-        An input widget of a special kind. For example, Goto Anything is an overlay.
+   overlay
+      An input widget of a special kind. For example, Goto Anything is an overlay.
 
-    file type
-        In the context of Sublime Text, *file type* refers to the type of file
-        as determined by the applicable ``.tmLanguage`` syntax definition.
+   file type
+      In the context of Sublime Text, *file type* refers to the type of file
+      as determined by the applicable ``.tmLanguage`` syntax definition.
 
-        However, this is an ambiguous term, and in some instances it could also
-        be used with the broader meaning it has in technical texts.
+      However, this is an ambiguous term, and in some instances it could also
+      be used with the broader meaning it has in technical texts.


### PR DESCRIPTION
Hm yeah, I basically rewrote the entire thing. Review by commit recommended.

Since package terminology is now defined using a glossay, it allows things
like `:term:`user package <user packages>``.
