### PR TITLE
typo in toggle_side_bar command

### DIFF
--- a/source/reference/commands.rst
+++ b/source/reference/commands.rst
@@ -197,7 +197,7 @@ Commands
 **refresh_folder_list**
 	Reloads all folders in the current project and updates the side bar.
 
-**toggle_sidebar**
+**toggle_side_bar**
 	Shows or hides the sidebar.
 
 **toggle_show_open_files**


### PR DESCRIPTION
It's not `toggle_sidebar`, it's `toggle_side_bar`. Both in my currently installed version of Sublime Text 3, and in a [two-minute Google search](https://www.google.co.uk/webhp?q=sublime%20text%20toggle%20side%20bar), e.g. [here](http://arrogantprogrammer.blogspot.co.uk/2013/05/toggle-sidebar-in-sublime-text.html) and [here](https://www.sublimetext.com/forum/viewtopic.php?f=3&t=8566).
