### PR TITLE
Fix broken Onigurama link

### DIFF
--- a/source/reference/symbols.rst
+++ b/source/reference/symbols.rst
@@ -270,7 +270,7 @@ in a symbol definition file:
          s/def\s+([A-Za-z_][A-Za-z0-9_]*\()(?:(.{0,40}?\))|((.{40}).+?\)))(\:)/$1(?2:$2)(?3:$4…\))/g;
       </string>
 
-.. _Oniguruma: http://www.geocities.jp/kosako3/oniguruma/
+.. _Oniguruma: https://github.com/kkos/oniguruma
 
 .. TODO: Are there more settings/options?
 


### PR DESCRIPTION
The link to the Onigurama geocities page. The repository is now on GitHub, so I've linked to that.
