### PR TITLE
on_query_completions flags

### DIFF
--- a/source/reference/api.rst
+++ b/source/reference/api.rst
@@ -215,7 +215,12 @@ module :py:mod:`sublime_plugin`
                     the completion list after all plugins have been processed.
 
                 ``sublime.INHIBIT_EXPLICIT_COMPLETIONS``
-                    XXX What does this do?
+                    Prevents Sublime Text from suggesting entries from
+                    ``.sublime-completions`` files.
+                    Therefore, with this flag set, it will only show completions
+                    that are returned by plugins from their
+                    ``on_query_completions`` methods (along with word
+                    completions unless the above flag is also set.)
 
                 Flags are shared among all completions, once set by one
                 plugin you can not revert them.

--- a/source/reference/api.rst
+++ b/source/reference/api.rst
@@ -213,6 +213,8 @@ module :py:mod:`sublime_plugin`
                 ``sublime.INHIBIT_WORD_COMPLETIONS``
                     Prevents Sublime Text from adding its word completions to
                     the completion list after all plugins have been processed.
+                    This consists of any word in the current document that is
+                    longer than 3 characters.
 
                 ``sublime.INHIBIT_EXPLICIT_COMPLETIONS``
                     Prevents Sublime Text from suggesting entries from


### PR DESCRIPTION
Hi,

I have added missing information to the details relating to the `on_query_completions` flags in `api.rst`.

[Related forum post](https://forum.sublimetext.com/t/solved-inhibit-word-completions-vs-inhibit-explicit-completions/18957)
