### PR TITLE
Make "Learning the API" less off-putting

### DIFF
--- a/source/extensibility/plugins.rst
+++ b/source/extensibility/plugins.rst
@@ -216,12 +216,11 @@ for plugins go, this a very bad one.
 Learning the API
 ****************
 
-In order to create plugins, you need to get acquainted with the Sublime Text
-API and the available commands. Documentation on both is scarce at the time of
-this writing, but you can read existing code and learn from it.
+The API reference is documented at `www.sublimetext.com/docs/3/api_reference.html <http://www.sublimetext.com/docs/3/api_reference.html>`
+
+To get acquainted with the Sublime Text API and the available commands, 
+it may be helpful to read existing code and learn from it.
 
 In particular, the :file:`Packages/Default` contains many examples of
 undocumented commands and API calls. Note that you will first have to extract
-its content to a folder if you want to take a look at the code within. As an
-exercise, you can try creating a build system to do that on demand, and a
-project file to be able to peek at the sample code easily.
+its contents to a folder if you want to take a look at the code within.

--- a/source/extensibility/plugins.rst
+++ b/source/extensibility/plugins.rst
@@ -223,4 +223,4 @@ it may be helpful to read existing code and learn from it.
 
 In particular, the :file:`Packages/Default` contains many examples of
 undocumented commands and API calls. Note that you will first have to extract
-its contents to a folder if you want to take a look at the code within.
+its contents to a folder if you want to take a look at the code within - `PackageResourceViewer <https://packagecontrol.io/packages/PackageResourceViewer>` helps with this.


### PR DESCRIPTION
The line "Documentation on both is scarce at the time of this writing, but you can read existing code and learn from it" screams "bugger off, you're not supposed to be making a plugin".

Considering that there appears to be decent API documentation, it seems much more encouraging to just link to it.

Beyond that, "you will first have to extract its content to a folder if you want to take a look at the code within. As an exercise, you can try creating a build system to do that on demand" says "learning is hard, and you should do work before you can start".

This pull request attempts to make the final lines of this introduction to plugins less off-putting.