### PR TITLE
Fix "soft-undo" hotkey

### DIFF
--- a/source/reference/keyboard_shortcuts_osx.rst
+++ b/source/reference/keyboard_shortcuts_osx.rst
@@ -65,7 +65,7 @@ Editing
 +-----------------+-----------------------------------------------------------+
 | ⌃ + Space       | Select next auto-complete suggestion                      |
 +-----------------+-----------------------------------------------------------+
-| ⌃ + U           | Soft undo; jumps to your last change before               |
+| ⌘ + U           | Soft undo; jumps to your last change before               |
 |                 | undoing change when repeated                              |
 +-----------------+-----------------------------------------------------------+
 | ⌃ + ⇧ + Up      | Column selection up                                       |


### PR DESCRIPTION
On OSX the soft undo is Command+U, it was mistakenly typed as Control+U.