### PR TITLE
Update stated keybinding in Macros Instructions

### DIFF
--- a/source/extensibility/macros.rst
+++ b/source/extensibility/macros.rst
@@ -13,11 +13,11 @@ deletion. You can find these under **Tools | Macros** or in
 How to Record Macros
 ********************
 
-To start recording a macro, press :kbd:`Ctrl+alt+q` and subsequently execute the
-desired steps one by one. When you're done, press :kbd:`Ctrl+alt+q` again to stop
+To start recording a macro, press :kbd:`Ctrl+Alt+q` and subsequently execute the
+desired steps one by one. When you're done, press :kbd:`Ctrl+Alt+q` again to stop
 the macro recorder. Your new macro won't be saved to a file, but kept in the
 macro buffer instead. Now you will be able to run the recorded macro by
-pressing :kbd:`Ctrl+Shift+q`, or save it to a file by selecting
+pressing :kbd:`Ctrl+Shift+Alt+q`, or save it to a file by selecting
 **Tools | Save macro...**
 
 Note that the macro buffer will remember only the latest recorded macro. Also,

--- a/source/extensibility/macros.rst
+++ b/source/extensibility/macros.rst
@@ -13,8 +13,8 @@ deletion. You can find these under **Tools | Macros** or in
 How to Record Macros
 ********************
 
-To start recording a macro, press :kbd:`Ctrl+q` and subsequently execute the
-desired steps one by one. When you're done, press :kbd:`Ctrl+q` again to stop
+To start recording a macro, press :kbd:`Ctrl+alt+q` and subsequently execute the
+desired steps one by one. When you're done, press :kbd:`Ctrl+alt+q` again to stop
 the macro recorder. Your new macro won't be saved to a file, but kept in the
 macro buffer instead. Now you will be able to run the recorded macro by
 pressing :kbd:`Ctrl+Shift+q`, or save it to a file by selecting


### PR DESCRIPTION
The doc states to start/stop macros using ctrl+q, however ctrl+q quits sublime text. The command for recording a macro is ctrl+alt+q