### PR TITLE
Key bindings.  Clarify which operators are available for which key va…

### DIFF
--- a/source/reference/key_bindings.rst
+++ b/source/reference/key_bindings.rst
@@ -178,10 +178,10 @@ Context Operators
    Test for equality.
 
 ``regex_match``, ``not_regex_match``
-   Match against a regular expression (full match).
+   Match against a regular expression (full match).  Available only for ``key`` values ``preceding_text``, ``following_text``, and ``text``.
 
 ``regex_contains``, ``not_regex_contains``
-   Match against a regular expression (partial match).
+   Match against a regular expression (partial match).  Available only for ``key`` values ``preceding_text``, ``following_text``, and ``text``.
 
 
 


### PR DESCRIPTION
…lues.  (Regex ones only for text.)

Contrary to the current version of this documentation, the "regex" operators are only available for `text/following_text/preceding_text`.  See https://forum.sublimetext.com/t/selector-on-a-keybind/3785/4